### PR TITLE
Update `rb_gc_mark_locations` doc

### DIFF
--- a/include/ruby/internal/intern/gc.h
+++ b/include/ruby/internal/intern/gc.h
@@ -71,7 +71,7 @@ RBIMPL_ATTR_NONNULL((1))
  *              addressable.
  * @param[out]  start  Pointer to an array of objects.
  * @param[out]  end    Pointer that terminates the array of objects.
- * @post        Objects from `start` to `end`, both inclusive, are marked.
+ * @post        Objects from `start` (included) to `end` (excluded) are marked.
  *
  * @internal
  *


### PR DESCRIPTION
The documentation says that the `end` pointer will be marked but [looking at the source](https://github.com/ruby/ruby/blob/7cd0dacb0b50cc3203aafc10bf2d7eb7678225aa/gc.c#L6482-L6490), that is not the case:

```c
static void
gc_mark_locations(rb_objspace_t *objspace, const VALUE *start, const VALUE *end, void (*cb)(rb_objspace_t *, VALUE))
{
    long n;


    if (end <= start) return;
    n = end - start;
    each_location(objspace, start, n, cb);
}
```
